### PR TITLE
Update PixieDust permalink

### DIFF
--- a/_features/pixiedust.md
+++ b/_features/pixiedust.md
@@ -2,7 +2,7 @@
 title:      PixieDust
 headline:   An open source helper library for Python notebooks. It makes working with data simpler.
 story:      Working with data is a team sport.
-permalink:  pixiedust
+permalink:  pixiedust-for-jupyter
 layout:     layout-featured-collection
 featured:   true
 # img:        pixiedust-logo.png


### PR DESCRIPTION
So there’s no name collision with the actual PixieDust docs site.