### PR TITLE
Adds step to ensure latest version of XCode and XCode CLI tools 

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ To preview the site and test changes locally Jekyll will need to be set up.
 The following requirements should be in place before trying to launch the site locally.
 
 * Ruby 2.1.0 or higher installed: `ruby --version`
+* [Mac OSX] Install latest version of XCode
+    * Ensure CLI tools are installed: run `xcode-select --install`
 * Bundler installed: `gem install bundler`
 * Clone the GitHub repo
 


### PR DESCRIPTION
Adds step to ensure latest version of XCode and XCode CLI tools are installed.

Running `xcode-select --install` ensures the latest versions are installed,
along with necessary libraries.

Doing this fixed my issue with installation problems:
https://github.com/ibm-watson-data-lab/ibm-watson-data-lab.github.io/issues/105