### PR TITLE
Style updates to msg about internal use only

### DIFF
--- a/css/exhibit.css
+++ b/css/exhibit.css
@@ -380,6 +380,10 @@ figcaption {
   color: light-grey;
 }
 
+.warning {
+  color: red;
+}
+
 
 
 

--- a/strategies.md
+++ b/strategies.md
@@ -6,7 +6,7 @@ id:     strategies
 
 # Strategies and their owners
 
-> <span class="warning">This page is for <em>internal use only</em> and is not linked to from any other site pages. The strategies and collections here are the same as those live on the site today, which means this is not a complete list of the work we're doing.</span>
+> <span class="warning">This page is for <strong>internal use only</strong> and is not linked to from any other site pages. The strategies and collections here are the same as those live on the site today, which means this is not a complete list of the work we're doing.</span>
 
 {% assign items = site.strategies %}
 {% assign authors = site.authors %}

--- a/strategies.md
+++ b/strategies.md
@@ -6,7 +6,7 @@ id:     strategies
 
 # Strategies and their owners
 
-> This page is for internal use only and is not linked to from any other site pages. The strategies and collections here are the same as those live on the site today, which means this is not a complete list of the work we're doing.
+> <span style="color: red">This page is for <b>internal use only</b> and is not linked to from any other site pages. The strategies and collections here are the same as those live on the site today, which means this is not a complete list of the work we're doing.</span>
 
 {% assign items = site.strategies %}
 {% assign authors = site.authors %}

--- a/strategies.md
+++ b/strategies.md
@@ -6,7 +6,7 @@ id:     strategies
 
 # Strategies and their owners
 
-> <span style="color: red">This page is for <b>internal use only</b> and is not linked to from any other site pages. The strategies and collections here are the same as those live on the site today, which means this is not a complete list of the work we're doing.</span>
+> <span class="warning">This page is for <em>internal use only</em> and is not linked to from any other site pages. The strategies and collections here are the same as those live on the site today, which means this is not a complete list of the work we're doing.</span>
 
 {% assign items = site.strategies %}
 {% assign authors = site.authors %}


### PR DESCRIPTION
This update affects the styling of the warning about our strategies page (which is publically accessible) being intended for internal use only. New version of that blurb is in red with "internal use only" in bold, like so: 

![image](https://user-images.githubusercontent.com/19171465/31956383-5076fae2-b8b9-11e7-8dc5-747a606fc0f5.png)
